### PR TITLE
bump vcn version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://codenotary/vcn:0.7' 
+  image: 'docker://codenotary/vcn:0.9' 
   args: ["a", "git://${{ inputs.path }}"]
   env:
     VCN_SIGNERID: ${{ inputs.signerID }}


### PR DESCRIPTION
this actions depends on vcn 0.7 and it raises the following error when building

<img width="753" alt="Screenshot 2021-09-07 at 12 17 21" src="https://user-images.githubusercontent.com/1845515/132329776-4cc8b9aa-43c2-4266-ab16-7cf70da27302.png">

I did a bump to vcn 0.9
